### PR TITLE
Added: Support modular models

### DIFF
--- a/docs/data-sources/authorization_model_document.md
+++ b/docs/data-sources/authorization_model_document.md
@@ -45,9 +45,10 @@ data "openfga_authorization_model_document" "model" {
 
 ### Optional
 
-- `dsl` (String) An authorization model in DSL format. Conflicts with `json` and `model` fields.
-- `json` (String) An authorization model in JSON format. Conflicts with `dsl` and `model` fields.
-- `model` (Attributes) An authorization model as Terraform object. Conflicts with `dsl` and `json` fields. (see [below for nested schema](#nestedatt--model))
+- `dsl` (String) An authorization model in DSL format. Conflicts with `json`, `model` and `mod_file_path` fields.
+- `json` (String) An authorization model in JSON format. Conflicts with `dsl`, `model` and `mod_file_path` fields.
+- `mod_file_path` (String) A file path to an `fga.mod` file. Conflicts with `json`, `model` and `dsl` fields.
+- `model` (Attributes) An authorization model as Terraform object. Conflicts with `dsl`, `json` and `mod_file_path` fields. (see [below for nested schema](#nestedatt--model))
 
 ### Read-Only
 

--- a/internal/provider/acceptance/modularmodel/conditions/larger_than.fga
+++ b/internal/provider/acceptance/modularmodel/conditions/larger_than.fga
@@ -1,0 +1,5 @@
+module conditions
+
+condition larger_than(a: int, b: int) {
+	a > b
+}

--- a/internal/provider/acceptance/modularmodel/document.fga
+++ b/internal/provider/acceptance/modularmodel/document.fga
@@ -1,0 +1,5 @@
+module document
+
+type document
+	relations
+		define viewer: [user]

--- a/internal/provider/acceptance/modularmodel/fga.mod
+++ b/internal/provider/acceptance/modularmodel/fga.mod
@@ -1,0 +1,5 @@
+schema: '1.2'
+contents:
+    - user.fga
+    - document.fga
+    - conditions/larger_than.fga

--- a/internal/provider/acceptance/modularmodel/user.fga
+++ b/internal/provider/acceptance/modularmodel/user.fga
@@ -1,0 +1,3 @@
+module user
+
+type user

--- a/internal/provider/authorizationmodel/authorization_model_document_data_source.go
+++ b/internal/provider/authorizationmodel/authorization_model_document_data_source.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -12,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	openfga "github.com/openfga/go-sdk"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/language/pkg/go/transformer"
 )
 
@@ -27,9 +29,10 @@ func NewAuthorizationModelDocumentDataSource() datasource.DataSource {
 type AuthorizationModelDocumentDataSource struct{}
 
 type AuthorizationModelDocumentDataSourceModel struct {
-	Dsl   types.String              `tfsdk:"dsl"`
-	Json  types.String              `tfsdk:"json"`
-	Model *CustomAuthorizationModel `tfsdk:"model"`
+	Dsl         types.String              `tfsdk:"dsl"`
+	ModFilePath types.String              `tfsdk:"mod_file_path"`
+	Json        types.String              `tfsdk:"json"`
+	Model       *CustomAuthorizationModel `tfsdk:"model"`
 
 	Result types.String `tfsdk:"result"`
 }
@@ -52,15 +55,19 @@ Using this data source to generate authorization models is optional. It is also 
 
 		Attributes: map[string]schema.Attribute{
 			"dsl": schema.StringAttribute{
-				MarkdownDescription: "An authorization model in DSL format. Conflicts with `json` and `model` fields.",
+				MarkdownDescription: "An authorization model in DSL format. Conflicts with `json`, `model` and `mod_file_path` fields.",
+				Optional:            true,
+			},
+			"mod_file_path": schema.StringAttribute{
+				MarkdownDescription: "A file path to an `fga.mod` file. Conflicts with `json`, `model` and `dsl` fields.",
 				Optional:            true,
 			},
 			"json": schema.StringAttribute{
-				MarkdownDescription: "An authorization model in JSON format. Conflicts with `dsl` and `model` fields.",
+				MarkdownDescription: "An authorization model in JSON format. Conflicts with `dsl`, `model` and `mod_file_path` fields.",
 				Optional:            true,
 			},
 			"model": schema.SingleNestedAttribute{
-				MarkdownDescription: "An authorization model as Terraform object. Conflicts with `dsl` and `json` fields.",
+				MarkdownDescription: "An authorization model as Terraform object. Conflicts with `dsl`, `json` and `mod_file_path` fields.",
 				Optional:            true,
 				Attributes:          CustomAuthorizationModelSchema(),
 			},
@@ -78,6 +85,7 @@ func (p AuthorizationModelDocumentDataSource) ConfigValidators(ctx context.Conte
 			path.MatchRoot("dsl"),
 			path.MatchRoot("json"),
 			path.MatchRoot("model"),
+			path.MatchRoot("mod_file_path"),
 		),
 	}
 }
@@ -98,62 +106,126 @@ func (d *AuthorizationModelDocumentDataSource) Read(ctx context.Context, req dat
 		return
 	}
 
-	model := state.Model
-	dslString := state.Dsl.ValueStringPointer()
-	jsonString := state.Json.ValueStringPointer()
-
-	if model != nil {
-		result, err := json.Marshal(state.Model)
-		if err != nil {
-			resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to transform model into JSON, got error: %s", err))
-			return
-		}
-
-		jsonString = openfga.PtrString(string(result))
-	}
-
-	if dslString != nil {
-		result, err := transformer.TransformDSLToJSON(*dslString)
-		if err != nil {
-			resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to transform DSL into JSON, got error: %s", err))
-			return
-		}
-
-		jsonString = openfga.PtrString(result)
-	}
-
-	if jsonString == nil {
-		resp.Diagnostics.AddError("Input Error", "JSON is undefined")
-		return
-	}
-
-	modelProto, err := transformer.LoadJSONStringToProto(*jsonString)
+	modelProto, err := extractAuthorizationModelProto(&state)
 	if err != nil {
-		resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to transform JSON into Proto, got error: %s", err))
+		resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to extract model from state, got error: %s", err))
 		return
 	}
 
+	json, err := marshalToSanitizedJson(modelProto)
+	if err != nil {
+		resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to marshal model into sanitized JSON, got error: %s", err))
+		return
+	}
+
+	state.Result = types.StringValue(json)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func extractAuthorizationModelProto(state *AuthorizationModelDocumentDataSourceModel) (*openfgav1.AuthorizationModel, error) {
+	if state.Model != nil {
+		return parseModelToAuthorizationModelProto(state.Model)
+	}
+
+	if state.ModFilePath.ValueString() != "" {
+		return parseModFileToAuthorizationModelProto(state.ModFilePath.ValueString())
+	}
+
+	if state.Dsl.ValueString() != "" {
+		return parseDslToAuthorizationModelProto(state.Dsl.ValueString())
+	}
+
+	if state.Json.ValueString() != "" {
+		return parseJsonToAuthorizationModelProto(state.Json.ValueString())
+	}
+
+	return nil, fmt.Errorf("at least one of model, mod file path, DSL or JSON has to be provided")
+}
+
+func parseModelToAuthorizationModelProto(model *CustomAuthorizationModel) (*openfgav1.AuthorizationModel, error) {
+	jsonBytes, err := json.Marshal(model)
+	if err != nil {
+		return nil, fmt.Errorf("unable to transform custom model into JSON, got error: %s", err)
+	}
+
+	return parseJsonToAuthorizationModelProto(string(jsonBytes))
+}
+
+func parseDslToAuthorizationModelProto(dsl string) (*openfgav1.AuthorizationModel, error) {
+	modelProto, err := transformer.TransformDSLToProto(dsl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to transform DSL into model proto, got error: %s", err)
+	}
+
+	return modelProto, nil
+}
+
+func parseModFileToAuthorizationModelProto(modFilePath string) (*openfgav1.AuthorizationModel, error) {
+	modFileBytes, err := os.ReadFile(modFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read mod file, got error: %s", err)
+	}
+
+	modFile, err := transformer.TransformModFile(string(modFileBytes))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse mod file, got error: %s", err)
+	}
+
+	modFileDirectory := filepath.Dir(modFilePath)
+
+	moduleFiles := []transformer.ModuleFile{}
+	for _, moduleFilePathProperty := range modFile.Contents.Value {
+		moduleFilePath := filepath.Join(modFileDirectory, moduleFilePathProperty.Value)
+
+		moduleFileBytes, err := os.ReadFile(moduleFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read module file, got error: %s", err)
+		}
+
+		moduleFile := transformer.ModuleFile{
+			Name:     moduleFilePath,
+			Contents: string(moduleFileBytes),
+		}
+
+		moduleFiles = append(moduleFiles, moduleFile)
+	}
+
+	modelProto, err := transformer.TransformModuleFilesToModel(moduleFiles, modFile.Schema.Value)
+	if err != nil {
+		return nil, fmt.Errorf("unable to transform module files into model proto, got error: %s", err)
+	}
+
+	return modelProto, nil
+}
+
+func parseJsonToAuthorizationModelProto(json string) (*openfgav1.AuthorizationModel, error) {
+	modelProto, err := transformer.LoadJSONStringToProto(json)
+	if err != nil {
+		return nil, fmt.Errorf("unable to transform JSON into model proto, got error: %s", err)
+	}
+
+	return modelProto, nil
+}
+
+func marshalToSanitizedJson(modelProto *openfgav1.AuthorizationModel) (string, error) {
 	marshaller := protojson.MarshalOptions{EmitDefaultValues: true}
+
 	unstableJsonBytes, err := marshaller.Marshal(modelProto)
 	if err != nil {
-		resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to bring JSON in canonical form, got error: %s", err))
-		return
+		return "", fmt.Errorf("unable to marshal model proto into unstable JSON, got error: %s", err)
 	}
 
 	var sanitizedAuthorizationModel AuthorizationModelWithoutId
 	err = json.Unmarshal(unstableJsonBytes, &sanitizedAuthorizationModel)
 	if err != nil {
-		resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to bring JSON in canonical form, got error: %s", err))
-		return
+		return "", fmt.Errorf("unable to unmarshal unstable JSON into sanitized model, got error: %s", err)
 	}
 
-	stableResultBytes, err := json.Marshal(sanitizedAuthorizationModel)
+	stableJsonBytes, err := json.Marshal(sanitizedAuthorizationModel)
 	if err != nil {
-		resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to bring JSON in canonical form, got error: %s", err))
-		return
+		return "", fmt.Errorf("unable to convert sanitized model into canonical JSON form, got error: %s", err)
 	}
 
-	state.Result = types.StringValue(string(stableResultBytes))
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	return string(stableJsonBytes), nil
 }

--- a/internal/provider/authorizationmodel/authorization_model_document_data_source_test.go
+++ b/internal/provider/authorizationmodel/authorization_model_document_data_source_test.go
@@ -28,6 +28,17 @@ func TestAccAuthorizationModelDocumentDataSource(t *testing.T) {
 					),
 				},
 			},
+			// Test mod file
+			{
+				Config: testAccAuthorizationModelDocumentDataSourceConfigModFile(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.openfga_authorization_model_document.test",
+						tfjsonpath.New("result"),
+						knownvalue.StringExact(expectedModularAuthorizationModelDocumentDataSourceResult),
+					),
+				},
+			},
 			// Test JSON
 			{
 				Config: testAccAuthorizationModelDocumentDataSourceConfigJson(),
@@ -55,6 +66,7 @@ func TestAccAuthorizationModelDocumentDataSource(t *testing.T) {
 }
 
 const expectedAuthorizationModelDocumentDataSourceResult = `{"conditions":{"larger_than":{"expression":"a \u003e b","name":"larger_than","parameters":{"a":{"generic_types":[],"type_name":"TYPE_NAME_INT"},"b":{"generic_types":[],"type_name":"TYPE_NAME_INT"}}}},"schema_version":"1.1","type_definitions":[{"relations":{},"type":"user"},{"metadata":{"module":"","relations":{"viewer":{"directly_related_user_types":[{"condition":"","type":"user"}],"module":""}}},"relations":{"viewer":{"this":{}}},"type":"document"}]}`
+const expectedModularAuthorizationModelDocumentDataSourceResult = `{"conditions":{"larger_than":{"expression":"a \u003e b","metadata":{"module":"conditions","source_info":{"file":"../acceptance/modularmodel/conditions/larger_than.fga"}},"name":"larger_than","parameters":{"a":{"generic_types":[],"type_name":"TYPE_NAME_INT"},"b":{"generic_types":[],"type_name":"TYPE_NAME_INT"}}}},"schema_version":"1.2","type_definitions":[{"metadata":{"module":"user","relations":{},"source_info":{"file":"../acceptance/modularmodel/user.fga"}},"relations":{},"type":"user"},{"metadata":{"module":"document","relations":{"viewer":{"directly_related_user_types":[{"condition":"","type":"user"}],"module":""}},"source_info":{"file":"../acceptance/modularmodel/document.fga"}},"relations":{"viewer":{"this":{}}},"type":"document"}]}`
 
 func testAccAuthorizationModelDocumentDataSourceConfigDsl() string {
 	return fmt.Sprintf(`
@@ -77,6 +89,15 @@ condition larger_than(a: int, b: int) {
 	EOT
 }
 `, acceptance.ProviderConfig)
+}
+
+func testAccAuthorizationModelDocumentDataSourceConfigModFile() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "openfga_authorization_model_document" "test" {
+	mod_file_path = "${path.root}/../acceptance/modularmodel/fga.mod"
+}`, acceptance.ProviderConfig)
 }
 
 func testAccAuthorizationModelDocumentDataSourceConfigJson() string {


### PR DESCRIPTION
This MR adds support for modular models in the `authorization_model_document` data source.

A new attribute `mod_file_path` was added to the data source. It conflicts with any of the existing attributes. If specified, the file at the file path will be parsed as an OpenFGA `.mod` file. If this is successful, every specified module file will be read and parsed. Finally, all module files will be parsed into the resulting authorization model. This model will have the corresponding `metadata` fields populated, based on the source files.

Example:
```terraform
data "authorization_model_document" "model" {
  mod_file_path = "${path.root}/../models/modular-model/fga.mod"
}
```

Closes #9