### PR TITLE
feat(provider)!: aligned names of provider attributes with official schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ provider "openfga" {
 
 ```terraform
 provider "openfga" {
-  api_url            = "http://openfga:8080" # or use FGA_API_URL
-  client_id          = "..."                 # or use FGA_CLIENT_ID
-  client_secret      = var.client_secret     # or use FGA_CLIENT_SECRET
-  token_endpoint_url = "http://example.com"  # or use FGA_TOKEN_ENDPOINT_URL
-  audience           = "..."                 # or use FGA_AUDIENCE
-  scopes             = "..."                 # or use FGA_SCOPES
+  api_url          = "http://openfga:8080" # or use FGA_API_URL
+  client_id        = "..."                 # or use FGA_CLIENT_ID
+  client_secret    = var.client_secret     # or use FGA_CLIENT_SECRET
+  api_token_issuer = "http://example.com"  # or use FGA_API_TOKEN_ISSUER
+  api_audience     = "..."                 # or use FGA_API_AUDIENCE
+  api_scopes       = "..."                 # or use FGA_API_SCOPES
 }
 ```
 
@@ -126,9 +126,9 @@ The available environment variables are:
 - `FGA_API_TOKEN`
 - `FGA_CLIENT_ID`
 - `FGA_CLIENT_SECRET`
-- `FGA_SCOPES`
-- `FGA_AUDIENCE`
-- `FGA_TOKEN_ENDPOINT_URL`
+- `FGA_API_SCOPES`
+- `FGA_API_AUDIENCE`
+- `FGA_API_TOKEN_ISSUER`
 
 ### Using the Provider
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ If you configured your OpenFGA server to use [pre-shared key authentication](htt
 
 ### OIDC authentication
 
-If you configured your OpenFGA server to use [OIDC authentication](https://openfga.dev/docs/getting-started/setup-openfga/configure-openfga#oidc), set the `client_id`, `client_secret` and `token_endpoint_url` fields in the provider configuration.
+If you configured your OpenFGA server to use [OIDC authentication](https://openfga.dev/docs/getting-started/setup-openfga/configure-openfga#oidc), set the `client_id`, `client_secret` and `api_token_issuer` fields in the provider configuration.
 
 -> This will make the provider obtain an access token with the provided credentials. If you already obtained a valid access token via other means, use the `api_token` field instead.
 
@@ -52,9 +52,9 @@ provider "openfga" {
 provider "openfga" {
   api_url = "http://localhost:8080"
 
-  client_id          = var.openfga_client_id
-  client_secret      = var.openfga_client_secret
-  token_endpoint_url = var.openfga_token_endpoint_url
+  client_id        = var.openfga_client_id
+  client_secret    = var.openfga_client_secret
+  api_token_issuer = var.openfga_api_token_issuer
 }
 ```
 
@@ -63,10 +63,10 @@ provider "openfga" {
 
 ### Optional
 
+- `api_audience` (String) Audience for client credentials authentication. This can also be sourced from the `FGA_API_AUDIENCE` environment variable.
+- `api_scopes` (String) Scopes for client credentials authentication. This can also be sourced from the `FGA_API_SCOPES` environment variable.
 - `api_token` (String) Access token for authentication to the OpenFGA server. This can also be sourced from the `FGA_API_TOKEN` environment variable.
+- `api_token_issuer` (String) The issuer URL or full token endpoint URL for client credentials authentication. If only the issuer URL is provided, the `oauth/token` path is used to retrieve an access token. This can also be sourced from the `FGA_API_TOKEN_ISSUER` environment variable.
 - `api_url` (String) URL of the OpenFGA server. This can also be sourced from the `FGA_API_URL` environment variable.
-- `audience` (String) Audience for client credentials authentication. This can also be sourced from the `FGA_AUDIENCE` environment variable.
 - `client_id` (String) Client ID for client credentials authentication. This can also be sourced from the `FGA_CLIENT_ID` environment variable.
 - `client_secret` (String, Sensitive) Client secret for client credentials authentication. This can also be sourced from the `FGA_CLIENT_SECRET` environment variable.
-- `scopes` (String) Scopes for client credentials authentication. This can also be sourced from the `FGA_SCOPES` environment variable.
-- `token_endpoint_url` (String) The token endpoint URL for client credentials authentication. This can also be sourced from the `FGA_TOKEN_ENDPOINT_URL` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -14,7 +14,7 @@ provider "openfga" {
 provider "openfga" {
   api_url = "http://localhost:8080"
 
-  client_id          = var.openfga_client_id
-  client_secret      = var.openfga_client_secret
-  token_endpoint_url = var.openfga_token_endpoint_url
+  client_id        = var.openfga_client_id
+  client_secret    = var.openfga_client_secret
+  api_token_issuer = var.openfga_api_token_issuer
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -26,7 +26,7 @@ If you configured your OpenFGA server to use [pre-shared key authentication](htt
 
 ### OIDC authentication
 
-If you configured your OpenFGA server to use [OIDC authentication](https://openfga.dev/docs/getting-started/setup-openfga/configure-openfga#oidc), set the `client_id`, `client_secret` and `token_endpoint_url` fields in the provider configuration.
+If you configured your OpenFGA server to use [OIDC authentication](https://openfga.dev/docs/getting-started/setup-openfga/configure-openfga#oidc), set the `client_id`, `client_secret` and `api_token_issuer` fields in the provider configuration.
 
 -> This will make the provider obtain an access token with the provided credentials. If you already obtained a valid access token via other means, use the `api_token` field instead.
 


### PR DESCRIPTION
🚨 **BREAKING** 🚨
This PR changes the provider attributes to match the official OpenFGA naming schema (i.e., same as CLI, etc,)

## Description
Changes the following fields and related ENV variables:
- `audience` -> `api_audience` (`FGA_AUDIENCE`-> `FGA_API_AUDIENCE`)
- `scopes` -> `api_scopes` (`FGA_SCOPES`-> `FGA_API_SCOPES`)
- `token_endpoint_url` -> `api_token_issuer` (`FGA_TOKEN_ENDPOINT_URL`-> `FGA_API_TOKEN_ISSUER`)

## References
- [CLI docs](https://github.com/openfga/cli/#configuration)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

